### PR TITLE
feat: animated tile rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,25 @@ poetry run game
 # Format and lint code
 poetry run format
 ```
+
+## Animated Tiles
+
+Terrain and background tiles now support simple sprite animations. In your tile
+TOML, keep the existing `sprite` field for static tiles, or supply a `sprites`
+array where each entry specifies the sprite name and how many frames it should
+display:
+
+```toml
+[[tiles]]
+slug = "item_box"
+sprite_sheet = "item_box"
+sprites = [
+    { sprite = "item_box_1", frames = 6 },
+    { sprite = "item_box_2", frames = 6 },
+    { sprite = "item_box_3", frames = 6 },
+]
+collision_mask = "full"
+```
+
+The animation clock advances once per world update, so a `frames` value of 6
+shows the sprite for roughly one tenth of a second at 60 FPS.

--- a/game/assets/sprites/item_box.yaml
+++ b/game/assets/sprites/item_box.yaml
@@ -1,0 +1,15 @@
+version: 1
+sprite_sheets:
+  item_box:
+    image: background.png
+    colorkey: [146, 144, 255]
+    sprites:
+      item_box_1:
+        offset: [298, 94]
+        size: [2, 2]
+      item_box_2:
+        offset: [315, 94]
+        size: [2, 2]
+      item_box_3:
+        offset: [332, 94]
+        size: [2, 2]

--- a/game/assets/tiles/collectables.toml
+++ b/game/assets/tiles/collectables.toml
@@ -5,8 +5,13 @@ full = 0b1111
 
 [[tiles]]
 slug = "item_box"
-sprite_sheet = "background"
-sprite = "item_box"
+sprite_sheet = "item_box"
+sprites = [
+    { sprite = "item_box_1", frames = 24 },
+    { sprite = "item_box_2", frames = 8 },
+    { sprite = "item_box_3", frames = 8 },
+    { sprite = "item_box_2", frames = 8 },
+]
 collision_mask = "full"
 simple_key = "?"
 

--- a/game/content/__init__.py
+++ b/game/content/__init__.py
@@ -11,7 +11,15 @@ from .tile_definitions import (
     require_tile,
     simple_tile_mapping,
 )
-from .types import SpriteFrame, SpriteKey, SpriteSheetDef, TileConfig, TileDefinition
+from .types import (
+    SpriteFrame,
+    SpriteKey,
+    SpriteSheetDef,
+    TileAnimation,
+    TileAnimationFrame,
+    TileConfig,
+    TileDefinition,
+)
 
 __all__ = [
     "SpriteLibrary",
@@ -20,6 +28,8 @@ __all__ = [
     "SpriteKey",
     "SpriteFrame",
     "SpriteSheetDef",
+    "TileAnimationFrame",
+    "TileAnimation",
     "TileConfig",
     "TileDefinition",
     "TILE_DEFS",

--- a/game/content/tile_definitions.py
+++ b/game/content/tile_definitions.py
@@ -15,6 +15,7 @@ def _build_tile_definition(record: TileConfig) -> TileDefinition:
         sprite_sheet=record.sprite_sheet,
         sprite_name=record.sprite,
         collision_mask=record.collision_mask,
+        animation=record.animation,
     )
 
 

--- a/game/content/types.py
+++ b/game/content/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Mapping
+from typing import Mapping, Tuple
 
 
 @dataclass(frozen=True)
@@ -34,6 +34,45 @@ class SpriteSheetDef:
 
 
 @dataclass(frozen=True, slots=True)
+class TileAnimationFrame:
+    """Single frame within an animated tile definition."""
+
+    sprite: str
+    frames: int
+
+    def __post_init__(self) -> None:
+        if self.frames <= 0:
+            raise ValueError("Tile animation frame durations must be positive.")
+
+
+@dataclass(frozen=True, slots=True)
+class TileAnimation:
+    """Animation metadata for tiles with multiple sprite frames."""
+
+    frames: Tuple[TileAnimationFrame, ...]
+    total_frames: int
+
+    def sprite_for_tick(self, tick: int) -> str:
+        """Resolve the sprite to use for the provided animation tick."""
+        if not self.frames:
+            raise ValueError("TileAnimation must contain at least one frame.")
+
+        if self.total_frames <= 0:
+            raise ValueError("TileAnimation total duration must be positive.")
+
+        position = tick % self.total_frames
+        cumulative = 0
+
+        for frame in self.frames:
+            cumulative += frame.frames
+            if position < cumulative:
+                return frame.sprite
+
+        # Fallback: return the final sprite (should be unreachable)
+        return self.frames[-1].sprite
+
+
+@dataclass(frozen=True, slots=True)
 class TileConfig:
     """Metadata for a single tile declared in TOML assets."""
 
@@ -43,6 +82,7 @@ class TileConfig:
     collision_mask: int
     category: str | None = None
     simple_key: str | None = None
+    animation: TileAnimation | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -52,3 +92,10 @@ class TileDefinition:
     sprite_sheet: str
     sprite_name: str | None
     collision_mask: int
+    animation: TileAnimation | None = None
+
+    def resolve_sprite_name(self, animation_tick: int) -> str | None:
+        """Return the appropriate sprite for the provided animation tick."""
+        if self.animation is not None:
+            return self.animation.sprite_for_tick(animation_tick)
+        return self.sprite_name

--- a/game/rendering/background.py
+++ b/game/rendering/background.py
@@ -21,7 +21,13 @@ class BackgroundLayer(RenderLayer):
 
         for tile_x, tile_y, tile_type in visible_tiles:
             tile_def = context.level.get_tile_definition(tile_type)
-            if not tile_def or not tile_def.sprite_name:
+            if not tile_def:
+                continue
+
+            sprite_name = tile_def.resolve_sprite_name(
+                context.game.world.animation_tick
+            )
+            if not sprite_name:
                 continue
 
             world_x = tile_x * TILE_SIZE
@@ -35,7 +41,7 @@ class BackgroundLayer(RenderLayer):
             sprites.draw_at_position(
                 context.surface,
                 tile_def.sprite_sheet,
-                tile_def.sprite_name,
+                sprite_name,
                 int(screen_x),
                 int(screen_y),
             )

--- a/game/rendering/terrain.py
+++ b/game/rendering/terrain.py
@@ -21,7 +21,13 @@ class TerrainLayer(RenderLayer):
 
         for tile_x, tile_y, tile_type in visible_tiles:
             tile_def = context.level.get_tile_definition(tile_type)
-            if not tile_def or not tile_def.sprite_name:
+            if not tile_def:
+                continue
+
+            sprite_name = tile_def.resolve_sprite_name(
+                context.game.world.animation_tick
+            )
+            if not sprite_name:
                 continue
 
             world_x: float = tile_x * TILE_SIZE
@@ -43,7 +49,7 @@ class TerrainLayer(RenderLayer):
             sprites.draw_at_position(
                 context.surface,
                 tile_def.sprite_sheet,
-                tile_def.sprite_name,
+                sprite_name,
                 int(screen_x),
                 int(screen_y),
             )

--- a/game/states/end_level.py
+++ b/game/states/end_level.py
@@ -255,7 +255,7 @@ class EndLevelState(State):
         if mario.screen != anchor.screen:
             return
 
-        trigger_x = anchor.world_x + TILE_SIZE * 0.5
+        trigger_x = anchor.world_x
         if mario.x < trigger_x:
             return
 
@@ -336,7 +336,7 @@ class EndLevelState(State):
             return None
 
         clamp_tile_y = unique_rows[-2] if len(unique_rows) >= 2 else unique_rows[-1]
-        return clamp_tile_y * TILE_SIZE
+        return float(clamp_tile_y * TILE_SIZE)
 
     def _apply_flagpole_top_clamp(self, mario) -> None:
         """Prevent Mario from hovering above the pole's top tiles."""

--- a/game/world.py
+++ b/game/world.py
@@ -28,6 +28,7 @@ class World:
         self.entity_factory = EntityFactory()
         self.props = PropManager()
         self.props.register("flagpole", FlagpoleProp())
+        self.animation_tick = 0
 
         # Create Mario at the level's spawn point
         self.mario = Mario(
@@ -59,6 +60,7 @@ class World:
         # Reset camera position and ratchet
         self.camera.x = 0
         self.camera.max_x = 0
+        self.animation_tick = 0
 
     def update(self, keys, dt: float) -> Optional[PhysicsEvent]:
         """Process Mario's intent and update his state.
@@ -81,9 +83,15 @@ class World:
 
         processed_context = self.physics.process(context)
 
+        triggered_event: Optional[PhysicsEvent] = None
         for event in processed_context.events:
             if event.dispatch(self, processed_context):
-                return cast(PhysicsEvent, event)
+                triggered_event = cast(PhysicsEvent, event)
+                break
+
+        if triggered_event is not None:
+            self.animation_tick += 1
+            return triggered_event
 
         self.props.update(self, dt)
         self.effects.update(dt)
@@ -91,6 +99,8 @@ class World:
         self.camera.update(self.mario.x, self.level.width_pixels)
 
         self._check_spawn_triggers()
+
+        self.animation_tick += 1
 
         return None
 


### PR DESCRIPTION
## Summary
- add TileAnimation metadata and extend the loader to parse per-frame sprite arrays while keeping single-sprite tiles working
- expose a world-level animation tick and render terrain/background tiles using the resolved sprite for the current frame
- move the item box to its own sprite sheet, update the tile asset to use the animation, and document the new TOML format

## Testing
- poetry run format *(mypy still fails at game/states/end_level.py:339; pre-existing)*
- not yet: manual gameplay check for animated tiles
