### PR TITLE
refactor: clarify Mario damage invulnerability

### DIFF
--- a/game/mario.py
+++ b/game/mario.py
@@ -221,9 +221,14 @@ class Mario(Drawable):
         )
 
     @property
-    def is_invincible(self) -> bool:
-        """Check if Mario is invincible (during transition)."""
+    def is_temporarily_invulnerable(self) -> bool:
+        """Return True while transitions or stomps suppress incoming damage."""
         return self.transition is not None or self.action == "stomping"
+
+    @property
+    def can_take_damage(self) -> bool:
+        """Return False whenever damage should be ignored."""
+        return not self.is_temporarily_invulnerable
 
     @staticmethod
     def _small_action(mario: "Mario") -> None:

--- a/game/physics/entity_collision.py
+++ b/game/physics/entity_collision.py
@@ -125,15 +125,15 @@ class EntityCollisionProcessor(PhysicsProcessor):
         mario.grow()
 
     def _apply_damage(self, context: PhysicsContext) -> None:
-        """Apply damage to Mario based on his current state.
+        """Apply damage to Mario based on his current state unless suppressed.
 
         - Small Mario: Dies
         - Big Mario: Shrinks to small
-        - Invincible: No effect
+        - Temporary invulnerability (transition or stomp): No effect
         """
         mario = context.mario
 
-        if mario.is_invincible:
+        if not mario.can_take_damage:
             return
 
         if mario.size == "small":


### PR DESCRIPTION
## Summary
- rename Mario's temporary invulnerability property for clarity
- add explicit `can_take_damage` helper to capture guard logic
- use the new helper when applying collision damage

## Testing
- not run (pending manual)
